### PR TITLE
Ocp 1739 consul upgrade 8 to 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .kitchen
+.idea

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,8 @@ provisioner:
   ansible_verbosity: 2
   ansible_diff: true
   ansible_extra_flags: <%= ENV['ANSIBLE_EXTRA_FLAGS'] %>
+  ignore_paths_from_root:
+    - .kitchen
 
 platforms:
   - name: ubuntu-14.04
@@ -38,3 +40,6 @@ suites:
     driver:
       network:
         - ["private_network", { ip: "172.29.129.184" }]
+
+transport:
+  max_ssh_sessions: 4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ consul_user:  consul
 consul_group: "{{ consul_user }}"
 consul_home:  "/opt/consul"
 
+consul_enable_script_checks: false
+
 consul_conf_dir:    "/etc/consul.d"
 consul_bin_dir:     "/usr/local/bin"
 consul_data_dir:    "{{ consul_home }}/data"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,4 +144,4 @@
   service: name=consul pattern={{ consul_bin_dir }}/consul enabled=yes state=started 
 
 - include: web_ui.yml
-  when: consul_install_web_ui or consul_node_type == 'client'
+  when: (consul_install_web_ui or consul_node_type == 'client') and not consul_version.startswith('0.9')

--- a/templates/client_config.json.j2
+++ b/templates/client_config.json.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "false"
 {
     "server": 	           false,
     "datacenter":          "{{ consul_datacenter|mandatory }}",
@@ -9,6 +10,10 @@
     "encrypt":             "{{ consul_encrypt_key }}",
     "log_level":           "{{ consul_log_level }}",
     "enable_syslog":       {{ consul_enable_syslog|default(false)|bool|lower }},
+{% if consul_version.startswith('0.9') %}
+    "enable_script_checks": {{ consul_enable_script_checks|default(false)|bool|lower }}
+
+{%  endif %}
     "leave_on_terminate":  {{ consul_leave_on_terminate|default(false)|bool|lower }},
     "start_join":          [ "{{ consul_nodes|join('", "') }}" ]
 }

--- a/templates/client_config.json.j2
+++ b/templates/client_config.json.j2
@@ -11,8 +11,7 @@
     "log_level":           "{{ consul_log_level }}",
     "enable_syslog":       {{ consul_enable_syslog|default(false)|bool|lower }},
 {% if consul_version.startswith('0.9') %}
-    "enable_script_checks": {{ consul_enable_script_checks|default(false)|bool|lower }}
-
+    "enable_script_checks": {{ consul_enable_script_checks|default(false)|bool|lower }},
 {%  endif %}
     "leave_on_terminate":  {{ consul_leave_on_terminate|default(false)|bool|lower }},
     "start_join":          [ "{{ consul_nodes|join('", "') }}" ]


### PR DESCRIPTION
To prepare for consul upgrade, the enable_script_checks parameter needs to be in client config for consul 0.9.x