### PR TITLE
PRI-289 [DM] Upgrade consul version to v1.0.1 and edit tests accordingly

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ consul_pip_pkgs:
 
 consul_prereq_pkgs: [ jq, unzip, python-pip ]
 
-consul_version: 0.7.5
+consul_version: 1.0.1
 consul_pkg:     "consul_{{ consul_version }}_linux_amd64.zip"
 consul_pkg_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/{{ consul_pkg }}"
 consul_checksum_file:     "consul_{{ consul_version }}_SHA256SUMS"

--- a/test/integration/client/serverspec/default_spec.rb
+++ b/test/integration/client/serverspec/default_spec.rb
@@ -26,7 +26,6 @@ end
   #{consul_home}/data
   #{consul_home}/logs
   #{consul_home}/scripts
-  #{consul_home}/ui
 ).each do |dir|
   describe file(dir) do
     it { should be_directory }
@@ -60,7 +59,7 @@ end
 
 describe command("#{consul_bin_dir}/consul --version") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match %r(Consul v0.7.5) }
+  its(:stdout) { should match %r(Consul v1.0.1) }
 end
 
 consul_scripts.each do |f|
@@ -93,12 +92,6 @@ end
 describe process('consul') do
   it { should be_running }
   its(:args) { should match %r(consul agent -config-dir .*) }
-end
-
-describe file("#{consul_home}/ui/index.html") do
-  it { should be_file }
-  it { should be_mode 644 }
-  it { should be_owned_by consul_user }
 end
 
 describe command("curl -s http://localhost:8500/v1/kv/?recurse | jq '.[] | .Key'") do

--- a/test/integration/server01/serverspec/default_spec.rb
+++ b/test/integration/server01/serverspec/default_spec.rb
@@ -26,7 +26,6 @@ end
   #{consul_home}/data
   #{consul_home}/logs
   #{consul_home}/scripts
-  #{consul_home}/ui
 ).each do |dir|
   describe file(dir) do
     it { should be_directory }
@@ -60,7 +59,7 @@ end
 
 describe command("#{consul_bin_dir}/consul --version") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match %r(Consul v0.7.5) }
+  its(:stdout) { should match %r(Consul v1.0.1) }
 end
 
 consul_scripts.each do |f|
@@ -95,8 +94,3 @@ describe process('consul') do
   its(:args) { should match %r(consul agent -config-dir .*) }
 end
 
-describe file("#{consul_home}/ui/index.html") do
-  it { should be_file }
-  it { should be_mode 644 }
-  it { should be_owned_by consul_user }
-end

--- a/test/integration/server02/serverspec/default_spec.rb
+++ b/test/integration/server02/serverspec/default_spec.rb
@@ -24,7 +24,7 @@ end
 
 describe command("#{consul_bin_dir}/consul --version") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match %r(Consul v0.7.5) }
+  its(:stdout) { should match %r(Consul v1.0.1) }
 end
 
 describe service('consul') do

--- a/test/integration/server03/serverspec/default_spec.rb
+++ b/test/integration/server03/serverspec/default_spec.rb
@@ -24,10 +24,10 @@ end
 
 describe command("#{consul_bin_dir}/consul --version") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match %r(Consul v0.7.5) }
+  its(:stdout) { should match %r(Consul v1.0.1) }
 end
 
-describe command("#{consul_bin_dir}/consul operator raft -list-peers| grep -c ':8300'") do
+describe command("#{consul_bin_dir}/consul operator raft list-peers| grep -c ':8300'") do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match '3' }
 end


### PR DESCRIPTION
Upgrade consul version and esit kitchen tests accordingly.

Tests updated:
1. Remove check for `ui` directory as it has been deprecated. 
   https://github.com/hashicorp/consul/pull/3292

2. Edit `raft` command as in the new version: `list-peers` is a SUB-COMMAND and not an argument 